### PR TITLE
Fix division by zero when text is empty

### DIFF
--- a/InteractiveHTMLBOM4Altium2.pas
+++ b/InteractiveHTMLBOM4Altium2.pas
@@ -1366,6 +1366,12 @@ var
   EdgeWidth, EdgeX1, EdgeY1, EdgeX2, EdgeHeight: String;
   EdgeType: String;
 begin
+  if Length(Prim.Text) = 0 then
+  begin
+    Result := '';
+    Exit;
+  end;
+
   PnPout := TStringList.Create;
 
   If (Prim.Layer = eTopOverlay) Then


### PR DESCRIPTION
Altium may contain text primitives with empty strings. Skip such objects to prevent division by zero when calculating character width.